### PR TITLE
Fix API timeouts and rate limiting

### DIFF
--- a/src/animation/uploader.rs
+++ b/src/animation/uploader.rs
@@ -79,7 +79,7 @@ impl AnimationUploader {
         use tokio::time::{Duration, sleep};
 
         let mut return_list: Vec<AssetBatchResponse> = Vec::new();
-        let batch_size = 100;
+        let batch_size = 250;
         let id_batches = asset_ids.chunks(batch_size);
         const MAX_RETRIES: i32 = 9;
 


### PR DESCRIPTION
Got copilot to fix it. Your request batch size was too large.
After building rerunning with same parameters as in my issue there were no more timeouts and it worked as intended.
<img width="576" height="231" alt="image" src="https://github.com/user-attachments/assets/208dd201-5966-4528-a533-6e017958e35e" />
